### PR TITLE
Add support for .NET 4.5.1 and 4.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # dotnetframework cookbook
 
-Installs and configures the .NET framework 4 or 4.5 runtime
+Installs and configures the .NET framework 4, 4.5, 4.5.1, or 4.5.2 runtime
 
 # Requirements
 
-Tested on Windows Server 2008 R2
-May work on Windows 7 or 8
+Tested on Windows Server 2008 R2, should work on versions of Windows supported
+by the associated .NET installer.
 
 # Usage
 
@@ -16,14 +16,14 @@ Include the default recipe in your run list.
 default
 -------
 
-* `node['dotnetframework']['version']` - defaults to '4.5' 
+* `node['dotnetframework']['version']` - defaults to '4.5.2' Acceptable values: '4.0', '4.5', '4.5.1', '4.5.2'.
 
 # Recipes
 
 default
 -------
 
-Installs the .NET Framework (4 or 4.5)
+Installs the .NET Framework
 
 # Author
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,11 +18,14 @@
 # limitations under the License.
 #
 
-default['dotnetframework']['version'] = '4.5'  # or 4.0
+# Override to install different .NET versions
+# 4.0, 4.5, 4.5.1, 4.5.2
+default['dotnetframework']['version'] = '4.5.2'
 
 
 # .NET 4.0
 default['dotnetframework']['4.0']['package_name'] = 'Microsoft .NET Framework 4 Extended'
+default['dotnetframework']['4.0']['version'] = '4.0.30319'
 default['dotnetframework']['4.0']['checksum'] =
   '65e064258f2e418816b304f646ff9e87af101e4c9552ab064bb74d281c38659f'
 default['dotnetframework']['4.0']['url'] = 'http://download.microsoft.com/download/9/5/A/' +
@@ -30,7 +33,24 @@ default['dotnetframework']['4.0']['url'] = 'http://download.microsoft.com/downlo
 
 # .NET 4.5
 default['dotnetframework']['4.5']['package_name'] = 'Microsoft .NET Framework 4.5'
+default['dotnetframework']['4.5']['version'] = '4.5.50709'
 default['dotnetframework']['4.5']['checksum'] =
   'a04d40e217b97326d46117d961ec4eda455e087b90637cb33dd6cc4a2c228d83'
 default['dotnetframework']['4.5']['url'] = 'http://download.microsoft.com/download/b/a/4/' +
   'ba4a7e71-2906-4b2d-a0e1-80cf16844f5f/dotnetfx45_full_x86_x64.exe'
+
+# .NET 4.5.1
+default['dotnetframework']['4.5.1']['package_name'] = 'Microsoft .NET Framework 4.5.1'
+default['dotnetframework']['4.5.1']['version'] = '4.5.50938'
+default['dotnetframework']['4.5.1']['checksum'] =
+  '5ded8628ce233a5afa8e0efc19ad34690f05e9bb492f2ed0413508546af890fe'
+default['dotnetframework']['4.5.1']['url'] = 'http://download.microsoft.com/download/1/6/7/' +
+  '167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe'
+
+# .NET 4.5.2
+default['dotnetframework']['4.5.2']['package_name'] = 'Microsoft .NET Framework 4.5.2'
+default['dotnetframework']['4.5.2']['version'] = '4.5.51209'
+default['dotnetframework']['4.5.2']['checksum'] =
+  '6c2c589132e830a185c5f40f82042bee3022e721a216680bd9b3995ba86f3781'
+default['dotnetframework']['4.5.2']['url'] = 'http://download.microsoft.com/download/E/2/1/' +
+  'E21644B5-2DF2-47C2-91BD-63C560427900/NDP452-KB2901907-x86-x64-AllOS-ENU.exe'

--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -1,10 +1,22 @@
 require 'minitest/spec'
+require 'win32/registry'
 
+# Tests to ensure .NET 4 is installed
 class TestDotNet4Install < MiniTest::Chef::TestCase
-
-  def test_framework_was_installed
-    dotnet4dir = File.join(ENV['WINDIR'], 'Microsoft.Net\\Framework64\\v4.0.30319')
-    assert Dir.exists?(dotnet4dir)
+  def test_framework_dir_exists
+    # all .NET versions are installed to the same v4.0.30319 folder
+    dir = File.join(ENV['WINDIR'], 'Microsoft.Net\\Framework64\\v4.0.30319')
+    assert Dir.exist?(dir)
   end
 
+  # Determining installed .NET versions
+  # http://support.microsoft.com/kb/318785
+  # https://msdn.microsoft.com/en-us/library/hh925568(v=vs.110).aspx
+  def test_framework_version
+    major_version = node['dotnetframework']['version']
+    path = 'SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full'
+    Win32::Registry::HKEY_LOCAL_MACHINE.open(path) do |reg|
+      assert reg['Version'] == node['dotnetframework'][major_version]['version']
+    end
+  end
 end


### PR DESCRIPTION
@heathsnow Since our WSUS server is patching our base boxes with .NET 4.5.2 it makes sense to have Chef match the same behavior.

- Add download defaults for .NET 4.5.1 and 4.5.2.
- Change the default .NET version to 4.5.2
- Add mini-test to validate the correct version of .NET was installed, especially useful for upgrade scenarios since all .NET 4.x versions install to the same directory.