### PR TITLE
only install and reboot once

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,5 +42,12 @@ windows_package package_name do
   options installer_cmd
   action :install
   success_codes [0, 3010]
+  not_if {
+    registry_value_exists?(
+      'HKLM\SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full', 
+      { :name => 'Version', :type => :string, :value => node['dotnetframework'][version]['version'] },
+      :machine
+    )
+  }  
   notifies :request, 'windows_reboot[60]', :immediately
 end


### PR DESCRIPTION
Hi,

Sorry for spamming you with pull requests, this is the final one :).

In using this cookbook I noticed that it kept rebooting servers as the windows_package resource could not verify properly that this package was already installed.

Therefore I added a not_if to the windows_package method that checks the register for the .net version specified in attributes.

Tested this on 2012r2 with .net 4.6.

Please consider.

Regards,

Frank Muller