### PR TITLE
Fixed Win32::Registry::Error on Win2012

### DIFF
--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -15,10 +15,24 @@ class TestDotNet4Install < MiniTest::Chef::TestCase
   # http://support.microsoft.com/kb/318785
   # https://msdn.microsoft.com/en-us/library/hh925568(v=vs.110).aspx
   def test_framework_version
+    expected_version = expected_dotnet_version
+    reg_version = installed_dotnet_version
+    flunk('Could not find a .NET version in the registry') unless reg_version
+    assert(Gem::Version.new(reg_version) >= Gem::Version.new(expected_version),
+      "Expected .NET version #{expected_version} or higher, but only found #{reg_version}")
+  end
+
+  def expected_dotnet_version
     major_version = node['dotnetframework']['version']
+    node['dotnetframework'][major_version]['version']
+  end
+
+  def installed_dotnet_version
     path = 'SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full'
     Win32::Registry::HKEY_LOCAL_MACHINE.open(path) do |reg|
-      assert reg['Version'] == node['dotnetframework'][major_version]['version'], reg['Version']
+      return reg['Version']
     end
+  rescue ::Win32::Registry::Error
+    return nil
   end
 end


### PR DESCRIPTION
@heathsnow @laynes This should fix the 'Win32::Registry::Error' we've been seeing on Windows 2012 R2. I also relaxed the constraints so the cookbook wouldn't fail if a newer version of .NET was already installed compared to the cookbook.
