### PR TITLE
Change min 4.6.1 build number from 01055 to 01038

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -87,7 +87,7 @@ default['dotnetframework']['4.6']['url'] = 'http://download.microsoft.com/downlo
 
 # .NET 4.6.1
 default['dotnetframework']['4.6.1']['package_name'] = 'Microsoft .NET Framework 4.6.1'
-default['dotnetframework']['4.6.1']['version'] = '4.6.01055'
+default['dotnetframework']['4.6.1']['version'] = '4.6.01038'
 default['dotnetframework']['4.6.1']['checksum'] =
   'beaa901e07347d056efe04e8961d5546c7518fab9246892178505a7ba631c301'
 default['dotnetframework']['4.6.1']['url'] = 'http://download.microsoft.com/download/E/4/1/' \


### PR DESCRIPTION
On Windows 10, the mini-test fails because the version number is 4.6.1.01038 instead of 4.6.1.01055. I believe this is because Windows 10 comes with .NET 4.6.1 pre-installed, albeit with a slightly lower version number, and the installer does not make any changes to this. To support this, the MSDN article (https://msdn.microsoft.com/en-us/library/hh925568%28v=vs.110%29.aspx#net_b) states that the release number in Windows 10 November Update is 394254, but for all other OS versions it is 394271.

I've tested this on my own box and it works :)